### PR TITLE
Fix spectators spawning outside of the map

### DIFF
--- a/src/main/java/com/github/voxxin/blockhunt/BlockHunt.java
+++ b/src/main/java/com/github/voxxin/blockhunt/BlockHunt.java
@@ -3,6 +3,9 @@ package com.github.voxxin.blockhunt;
 import com.github.voxxin.blockhunt.game.BlockHuntConfig;
 import com.github.voxxin.blockhunt.game.BlockHuntWaiting;
 import net.fabricmc.api.ModInitializer;
+import net.minecraft.network.packet.Packet;
+import net.minecraft.network.packet.s2c.play.EntityEquipmentUpdateS2CPacket;
+import net.minecraft.server.network.ServerPlayNetworkHandler;
 import net.minecraft.util.Identifier;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -29,4 +32,13 @@ public class BlockHunt implements ModInitializer {
         return Identifier.of(ID, value);
     }
     public static List<Integer> deniedIDs = new ArrayList<>();
+
+    public static boolean shouldCancel(Packet<?> packet, ServerPlayNetworkHandler handler) {
+        if (packet instanceof EntityEquipmentUpdateS2CPacket entityEquipmentUpdateS2CPacket) {
+            int packetID = entityEquipmentUpdateS2CPacket.getEntityId();
+            return handler.player.getWorld().getPlayers().stream().noneMatch(p -> p.getId() == packetID) || BlockHunt.deniedIDs.contains(packetID);
+        }
+
+        return false;
+    }
 }

--- a/src/main/java/com/github/voxxin/blockhunt/game/BlockHuntActive.java
+++ b/src/main/java/com/github/voxxin/blockhunt/game/BlockHuntActive.java
@@ -151,7 +151,7 @@ public class BlockHuntActive {
             game.listen(GameActivityEvents.ENABLE, active::onOpen);
 
             game.listen(GamePlayerEvents.OFFER, JoinOffer::accept);
-            game.listen(GamePlayerEvents.ACCEPT, (offer) -> offer.teleport(world, Vec3d.ZERO));
+            game.listen(GamePlayerEvents.ACCEPT, (offer) -> offer.teleport(world, map.getSpawnPos()));
             game.listen(GamePlayerEvents.ADD, active::addPlayer);
             game.listen(GamePlayerEvents.REMOVE, active::removePlayer);
 
@@ -269,7 +269,7 @@ public class BlockHuntActive {
     }
 
     private void addPlayer(ServerPlayerEntity player) {
-        if (gameSpace.getTime() < stageManager.finishTime && gameSpace.getTime() > stageManager.startTime) {
+        if (world.getTime() < stageManager.finishTime && world.getTime() > stageManager.startTime) {
             this.spawnLogic.resetPlayer(player, GameMode.SPECTATOR);
         }
     }

--- a/src/main/java/com/github/voxxin/blockhunt/game/BlockHuntWaiting.java
+++ b/src/main/java/com/github/voxxin/blockhunt/game/BlockHuntWaiting.java
@@ -85,7 +85,7 @@ public class BlockHuntWaiting {
             game.listen(GameActivityEvents.REQUEST_START, waiting::requestStart);
             game.listen(GamePlayerEvents.ADD, waiting::addPlayer);
             game.listen(GamePlayerEvents.OFFER, JoinOffer::accept);
-            game.listen(GamePlayerEvents.ACCEPT, (offer) -> offer.teleport(world, map.spawns().containsKey("spawn_everyone") ? map.spawns().get("spawn_everyone") : map.spawns().get("spawn_hider")));
+            game.listen(GamePlayerEvents.ACCEPT, (offer) -> offer.teleport(world, map.getSpawnPos()));
             game.listen(PlayerDeathEvent.EVENT, waiting::onPlayerDeath);
 
             game.listen(BlockUseEvent.EVENT, waiting::allowInteraction);

--- a/src/main/java/com/github/voxxin/blockhunt/game/map/BlockHuntMap.java
+++ b/src/main/java/com/github/voxxin/blockhunt/game/map/BlockHuntMap.java
@@ -21,6 +21,10 @@ import java.util.Map;
 
 public record BlockHuntMap(Map<String, Vec3d> spawns, ArrayList<Object> noInteractList,
                            ArrayList<Object> allowedDisguises, ArrayList<BlockHuntAnimation> animations, RuntimeWorldConfig worldConfig) {
+    public Vec3d getSpawnPos() {
+        return this.spawns().getOrDefault("spawn_everyone", this.spawns().get("spawn_hider"));
+    }
+    
     public static BlockHuntMap from(GameOpenContext<BlockHuntConfig> context) throws IOException {
         var server = context.server();
         var config = context.config();

--- a/src/main/java/com/github/voxxin/blockhunt/game/mixin/ServerPlayerNetworkHandlerMixin.java
+++ b/src/main/java/com/github/voxxin/blockhunt/game/mixin/ServerPlayerNetworkHandlerMixin.java
@@ -2,8 +2,9 @@ package com.github.voxxin.blockhunt.game.mixin;
 
 import com.github.voxxin.blockhunt.BlockHunt;
 import io.netty.channel.ChannelFutureListener;
+import net.minecraft.network.listener.ClientPlayPacketListener;
 import net.minecraft.network.packet.Packet;
-import net.minecraft.network.packet.s2c.play.EntityEquipmentUpdateS2CPacket;
+import net.minecraft.network.packet.s2c.play.BundleS2CPacket;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.network.ServerCommonNetworkHandler;
 import net.minecraft.server.network.ServerPlayerEntity;
@@ -13,7 +14,11 @@ import net.minecraft.server.network.ServerPlayNetworkHandler;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.ModifyVariable;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Mixin(ServerCommonNetworkHandler.class)
 public class ServerPlayerNetworkHandlerMixin {
@@ -21,11 +26,31 @@ public class ServerPlayerNetworkHandlerMixin {
     @Inject(at = @At("HEAD"), method = "send", cancellable = true)
     public void sendPacket(Packet<?> packet, ChannelFutureListener listener, CallbackInfo ci) {
         //noinspection ConstantValue
-        if (packet instanceof EntityEquipmentUpdateS2CPacket entityEquipmentUpdateS2CPacket && ((Object) this) instanceof ServerPlayNetworkHandler handler) {
-            int packetID = entityEquipmentUpdateS2CPacket.getEntityId();
-            if (handler.player.getWorld().getPlayers().stream().noneMatch(p -> p.getId() == packetID)) { ci.cancel(); }
-
-            if (BlockHunt.deniedIDs.contains(packetID)) { ci.cancel(); }
+        if (((Object) this) instanceof ServerPlayNetworkHandler handler && BlockHunt.shouldCancel(packet, handler)) {
+            ci.cancel();
         }
+    }
+
+    @ModifyVariable(at = @At("HEAD"), method = "send", argsOnly = true)
+    public Packet<?> sendPacket(Packet<?> packet) {
+        //noinspection ConstantValue
+        if (((Object) this) instanceof ServerPlayNetworkHandler handler && packet instanceof BundleS2CPacket bundleS2CPacket) {
+            List<Packet<? super ClientPlayPacketListener>> packets = new ArrayList<>();
+            boolean modified = false;
+
+            for (Packet<? super ClientPlayPacketListener> child : bundleS2CPacket.getPackets()) {
+                if (BlockHunt.shouldCancel(child, handler)) {
+                    modified = true;
+                } else {
+                    packets.add(child);
+                }
+            }
+
+            if (modified) {
+                return new BundleS2CPacket(packets);
+            }
+        }
+
+        return packet;
     }
 }


### PR DESCRIPTION
This pull request includes several fixes to spectator functionality:

- Changes the spawn positions of spectators from (0, 0, 0) to be the same as the waiting lobby spawns
- Fixes spectators not having the correct game mode (caused by the incorrect time being used in spawn calculations)
- Fixes spectators being able to see the leather armor of hiders (caused by bundle packets not being handled by the packet filter)